### PR TITLE
Added standard as an js linter

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,8 @@
     "react-router": "^2.0.0",
     "redial": "^0.4.1",
     "source-map-support": "^0.4.0",
+    "standard": "^8.6.0",
+    "standard-loader": "^5.0.0",
     "swig": "^1.4.2",
     "throng": "^4.0.0",
     "webpack": "^1.13.1",
@@ -51,5 +53,8 @@
   "devDependencies": {},
   "engines": {
     "node": "6.2.2"
+  },
+  "standard": {
+    "parser": "babel-eslint"
   }
 }

--- a/server/index.js
+++ b/server/index.js
@@ -39,9 +39,10 @@ app.disable('x-powered-by')
 app.engine('html', Swig.renderFile)
 app.set('view engine', 'html');
 app.set('views', path.join(__dirname, 'views'))
-app.use(express.static('public'));
 
-app.get('*', function(req, res) {
+app.use(express.static('public'))
+
+app.get('/', function(req, res) {
   res.render('index', { 
     vendorjs:  __PROD__ ? assets.vendor.js : '/vendor.js',
     bundlejs: __PROD__ ? assets.main.js : '/main.js'

--- a/tools/webpack.client.dev.js
+++ b/tools/webpack.client.dev.js
@@ -26,6 +26,13 @@ module.exports = {
     path: CLIENT_OUTPUT
   },
   module: {
+    preLoaders: [
+      {
+        test: /\.jsx?$/,
+        loader: 'standard',
+        exclude: /(node_modules)/
+      }
+	  ],
     loaders: [
       {
         test: /\.(js|jsx)$/,
@@ -40,6 +47,9 @@ module.exports = {
   },
   resolve: {
     extensions: ['', '.js', '.jsx']
+  },
+  standard: {
+    parser: 'babel-eslint'
   },
   plugins: [
     new webpack.DefinePlugin({


### PR DESCRIPTION
Will run the eslinter while in developer mode, won't block compiling the react templates, for the time being.